### PR TITLE
fix: 在安装依赖包后再导入 pypinyin 包

### DIFF
--- a/init.py
+++ b/init.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 import os
-import pypinyin
+import importlib
 
 # Install dependencies
 os.system('pip install -r requirements.txt')
+
+# Dynamic import pypinyin
+pypinyin = importlib.import_module('pypinyin')
 
 # Search pypinyin dict
 pypinyin_dir = Path(os.path.dirname(pypinyin.__file__))


### PR DESCRIPTION
调整pypinyin包导入的时机